### PR TITLE
fix: replace django-environ-2 with django-environ package

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,7 +8,7 @@ colorama
 dj-database-url
 Django
 django-bootstrap3
-django-environ-2
+django-environ
 django-filter
 django-model-utils
 djangorestframework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,13 +10,13 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via -r requirements/base.in
 colorama==0.4.6
     # via -r requirements/base.in
-dj-database-url==1.2.0
+dj-database-url==1.3.0
     # via -r requirements/base.in
 django==3.2.18
     # via
@@ -28,15 +28,13 @@ django==3.2.18
     #   django-filter
     #   django-model-utils
     #   djangorestframework
-django-bootstrap3==22.2
+django-bootstrap3==23.1
     # via -r requirements/base.in
 django-datetime-widget @ git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986
     # via -r requirements/base.in
-django-environ==0.9.0
-    # via django-environ-2
-django-environ-2==2.3.0
+django-environ==0.10.0
     # via -r requirements/base.in
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/base.in
 django-model-utils==4.3.1
     # via -r requirements/base.in
@@ -48,13 +46,13 @@ lazy-object-proxy==1.9.0
     # via -r requirements/base.in
 ordereddict==1.1
     # via -r requirements/base.in
-pygments==2.14.0
+pygments==2.15.1
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
 python-dotenv==1.0.0
     # via -r requirements/base.in
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.in
     #   django
@@ -70,9 +68,11 @@ six==1.16.0
     # via python-dateutil
 slacker==0.14.0
     # via -r requirements/base.in
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-urllib3==1.26.14
+typing-extensions==4.5.0
+    # via dj-database-url
+urllib3==1.26.15
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -8,15 +8,15 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.2
+pip-tools==6.13.0
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,13 +10,13 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via -r requirements/base.in
 colorama==0.4.6
     # via -r requirements/base.in
-dj-database-url==1.2.0
+dj-database-url==1.3.0
     # via -r requirements/base.in
 django==3.2.18
     # via
@@ -28,15 +28,13 @@ django==3.2.18
     #   django-filter
     #   django-model-utils
     #   djangorestframework
-django-bootstrap3==22.2
+django-bootstrap3==23.1
     # via -r requirements/base.in
 django-datetime-widget @ git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986
     # via -r requirements/base.in
-django-environ==0.9.0
-    # via django-environ-2
-django-environ-2==2.3.0
+django-environ==0.10.0
     # via -r requirements/base.in
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/base.in
 django-model-utils==4.3.1
     # via -r requirements/base.in
@@ -50,15 +48,15 @@ lazy-object-proxy==1.9.0
     # via -r requirements/base.in
 ordereddict==1.1
     # via -r requirements/base.in
-psycopg2==2.9.5
+psycopg2==2.9.6
     # via -r requirements/production.in
-pygments==2.14.0
+pygments==2.15.1
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
 python-dotenv==1.0.0
     # via -r requirements/base.in
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.in
     #   django
@@ -74,9 +72,11 @@ six==1.16.0
     # via python-dateutil
 slacker==0.14.0
     # via -r requirements/base.in
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-urllib3==1.26.14
+typing-extensions==4.5.0
+    # via dj-database-url
+urllib3==1.26.15
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -6,25 +6,23 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.14.2
+astroid==2.15.3
     # via pylint
-attrs==22.2.0
-    # via pytest
 boto==2.49.0
     # via -r requirements/base.in
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via -r requirements/base.in
 colorama==0.4.6
     # via -r requirements/base.in
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via pytest-cov
 dill==0.3.6
     # via pylint
-dj-database-url==1.2.0
+dj-database-url==1.3.0
     # via -r requirements/base.in
     # via
     #   -c requirements/common_constraints.txt
@@ -35,21 +33,19 @@ dj-database-url==1.2.0
     #   django-filter
     #   django-model-utils
     #   djangorestframework
-django-bootstrap3==22.2
+django-bootstrap3==23.1
     # via -r requirements/base.in
 django-datetime-widget @ git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986
     # via -r requirements/base.in
-django-environ==0.9.0
-    # via django-environ-2
-django-environ-2==2.3.0
+django-environ==0.10.0
     # via -r requirements/base.in
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/base.in
 django-model-utils==4.3.1
     # via -r requirements/base.in
 djangorestframework==3.14.0
     # via -r requirements/base.in
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -65,23 +61,23 @@ lazy-object-proxy==1.9.0
     #   astroid
 mccabe==0.7.0
     # via pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/testing.in
 ordereddict==1.1
     # via -r requirements/base.in
-packaging==23.0
+packaging==23.1
     # via pytest
-platformdirs==3.0.0
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via pytest
-psycopg2==2.9.5
+psycopg2==2.9.6
     # via -r requirements/production.in
-pygments==2.14.0
+pygments==2.15.1
     # via -r requirements/base.in
-pylint==2.16.2
+pylint==2.17.2
     # via -r requirements/testing.in
-pytest==7.2.1
+pytest==7.3.1
     # via
     #   -r requirements/testing.in
     #   pytest-cov
@@ -94,7 +90,7 @@ python-dateutil==2.8.2
     # via -r requirements/base.in
 python-dotenv==1.0.0
     # via -r requirements/base.in
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.in
     #   django
@@ -110,20 +106,21 @@ six==1.16.0
     # via python-dateutil
 slacker==0.14.0
     # via -r requirements/base.in
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 tomli==2.0.1
     # via
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via
     #   astroid
+    #   dj-database-url
     #   pylint
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in


### PR DESCRIPTION
### Description
- `django-environ-2` package has been deprecated in favour of `django-environ` package.