### PR TITLE
fix: Update `make upgrade` to use the correct python version.

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -16,6 +16,7 @@ jobs:
        team_reviewers: "arbi-bom"
        email_address: arbi-bom@edx.org
        send_success_notification: false
+       python_version: "3.11"
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
We upgraded this repo to use python 3.11 in production but we forgot to
ensure that the `make upgrade` job will run with the correct python
version.

Needs https://github.com/openedx/.github/pull/81 before we can merge
this.
